### PR TITLE
Fix "Invalid number" error in set /a

### DIFF
--- a/keygen.bat
+++ b/keygen.bat
@@ -1,3 +1,3 @@
 @echo off
 set /a key=13333+((1%TIME:~0,2%-100)*7113)+((1%TIME:~3,2%-100)*77)
-movdump.exe -key %key%
+movdump.exe -key %key% %*

--- a/keygen.bat
+++ b/keygen.bat
@@ -1,3 +1,3 @@
 @echo off
-set /a key=13333+(%TIME:~0,2%*7113)+(%TIME:~3,2%*77)
+set /a key=13333+((1%TIME:~0,2%-100)*7113)+((1%TIME:~3,2%-100)*77)
 movdump.exe -key %key%


### PR DESCRIPTION
Fixed "Invalid number.  Numeric constants are either decimal (17), hexadecimal (0x11), or octal (021)." error that occurs when the two-digit hour or minute is parsed as an octal number with invalid digits (08 or 09). This is corrected by concatenating a leading "1" digit onto the two-digit hours or minutes, making them parse as 3-digit decimal number (108 or 109), and then subtracting 100 from this to yield the correct 1- or 2-digit number (8 or 9).

E.g.
05 => 105 - 100 = 5 (illustrates that other 1-digit values are not affected)
08 => 108 - 100 = 8 (this would produce an error without correction, as 08 is an invalid octal number)
59 => 159 - 100 = 59 (illustrates that other 2-digit values are not affected)